### PR TITLE
tridents don't exist in pre-1.13

### DIFF
--- a/src/main/java/ac/grim/grimac/events/packets/PacketPlayerDigging.java
+++ b/src/main/java/ac/grim/grimac/events/packets/PacketPlayerDigging.java
@@ -103,7 +103,7 @@ public class PacketPlayerDigging extends PacketListenerAbstract {
         }
 
         // The client and server don't agree on trident status because mojang is incompetent at netcode.
-        if (material == ItemTypes.TRIDENT) {
+        if (material == ItemTypes.TRIDENT && (player.getClientVersion().isNewerThanOrEquals(ClientVersion.V_1_13_2) || player.getClientVersion().isOlderThanOrEquals(ClientVersion.V_1_8))) {
             player.packetStateData.setSlowedByUsingItem(item.getEnchantmentLevel(EnchantmentTypes.RIPTIDE, PacketEvents.getAPI().getServerManager().getVersion().toClientVersion()) <= 0);
             player.packetStateData.eatingHand = hand;
         }


### PR DESCRIPTION
but since via replaces them with diamond swords, 1.8 players will still be slowed